### PR TITLE
create background color picker feature for notepad

### DIFF
--- a/sidebar/note.css
+++ b/sidebar/note.css
@@ -30,6 +30,17 @@ p {
   outline: 0px solid transparent;
 }
 
+/*
+.lines {
+  border-left: 1px solid #ffaa9f;
+  border-right: 1px solid #ffaa9f;
+  width: 2px;
+  float: left;
+  height: 495px;
+  margin-left: 5px;
+}
+*/
+
 /* styles for background-color picker */
 input{
   margin: .4rem;
@@ -45,14 +56,3 @@ input{
 #colorInput{
   font-weight:bold;
 }
-
-/*
-.lines {
-  border-left: 1px solid #ffaa9f;
-  border-right: 1px solid #ffaa9f;
-  width: 2px;
-  float: left;
-  height: 495px;
-  margin-left: 5px;
-}
-*/

--- a/sidebar/note.css
+++ b/sidebar/note.css
@@ -30,6 +30,22 @@ p {
   outline: 0px solid transparent;
 }
 
+/* styles for background-color picker */
+input{
+  margin: .4rem;
+  font-size: 1rem;
+}
+
+#bgColorPicker{
+  display: flex;
+  padding-bottom: 4%;
+  padding-left: 4%;
+}
+
+#colorInput{
+  font-weight:bold;
+}
+
 /*
 .lines {
   border-left: 1px solid #ffaa9f;
@@ -40,6 +56,3 @@ p {
   margin-left: 5px;
 }
 */
-
-
-

--- a/sidebar/note.html
+++ b/sidebar/note.html
@@ -7,9 +7,7 @@
   </head>
 
 <body>
-  <div id="content">
-
-  </div>
+  <div id="content"></div>
 
   <div id= "bgColorPicker">
     <label for="colorInput">Background Color Picker:</label>

--- a/sidebar/note.html
+++ b/sidebar/note.html
@@ -7,7 +7,15 @@
   </head>
 
 <body>
-  <div id="content"></div>
+  <div id="content">
+
+  </div>
+
+  <div id= "bgColorPicker">
+    <label for="colorInput">Background Color Picker:</label>
+    <input id= "colorInput" type = "color" value = "#FFFCDB">
+  </div>
+
   <script src="note.js"></script>
 </body>
 

--- a/sidebar/note.js
+++ b/sidebar/note.js
@@ -35,7 +35,6 @@ function updateContent() {
     .then((tabs) => {
       contentBox.style.backgroundColor = backgroundColor;
       document.body.style.backgroundColor = backgroundColor;
-      console.log(backgroundColor);
       return browser.storage.sync.get(tabs[0].url);
     })
     .then((storedInfo) => {

--- a/sidebar/note.js
+++ b/sidebar/note.js
@@ -1,5 +1,21 @@
 var myWindowId;
+var backgroundColor;
 const contentBox = document.querySelector("#content");
+let colorChoice = document.getElementById("colorInput");
+
+
+//update background color of sticky when user closes color picker
+colorChoice.addEventListener("change", function(){
+  backgroundColor= colorChoice.value;
+  updateContent();
+});
+
+//update background color of sticky as user presses new color in color picker
+colorChoice.addEventListener("input", function(){
+  backgroundColor= colorChoice.value;
+  updateContent();
+});
+
 
 window.addEventListener("mouseover", () => {
   contentBox.setAttribute("contenteditable", true);
@@ -17,12 +33,18 @@ window.addEventListener("mouseout", () => {
 function updateContent() {
   browser.tabs.query({windowId: myWindowId, active: true})
     .then((tabs) => {
+      contentBox.style.backgroundColor = backgroundColor;
+      document.body.style.backgroundColor = backgroundColor;
+      console.log(backgroundColor);
       return browser.storage.sync.get(tabs[0].url);
     })
     .then((storedInfo) => {
       contentBox.textContent = storedInfo[Object.keys(storedInfo)[0]];
     });
 }
+
+
+
 
 browser.tabs.onActivated.addListener(updateContent);
 
@@ -31,4 +53,5 @@ browser.tabs.onUpdated.addListener(updateContent);
 browser.windows.getCurrent({populate: true}).then((windowInfo) => {
   myWindowId = windowInfo.id;
   updateContent();
+
 });


### PR DESCRIPTION
Pull Request to add background color picker functionality to the side notepad. So far, the basic functionality is operational, but these issues remain:

1. the change bgColor does not persist when the user closes the browser window and opens a new one. However, it persists between tabs and webpages.
2. the font color of the text does not change.
     We can either:
          - make another feature where the user can manually update the font-color with the bgColor, or
          - automatically change the font color based on the lightness or darkness of the new bgColor...see: [https://stackoverflow.com/questions/25680108/how-to-sort-color-codes-from-light-to-dark-in-java](https://stackoverflow.com/questions/25680108/how-to-sort-color-codes-from-light-to-dark-in-java)